### PR TITLE
feat(#5234): add parameter to override event bus name

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -363,7 +363,8 @@ class LambdaMode(ServerlessExecutionMode):
             'kms_key_arn': {'type': 'string'},
             'tracing_config': {'type': 'object'},
             'security_groups': {'type': 'array'},
-            'subnets': {'type': 'array'}
+            'subnets': {'type': 'array'},
+            'event-bus': {'type': 'string'}
         }
     }
 


### PR DESCRIPTION
This PR fixes upstream issue #5234 and adds support for passing custom event bus name to `lambda` mode policies.