### PR TITLE
feat(#5786): trim lambda function description to 256 chars

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -705,6 +705,12 @@ class AbstractLambdaFunction:
         if self.layers:
             conf['Layers'] = self.layers
 
+        if self.description and len(self.description) > 256:
+            conf['Description'] = conf['Description'].strip()[:256]
+            log.warning(
+                "Lambda function description trimmed to max length of 256"
+                " policy:%s " % (self.name))
+
         if self.environment['Variables']:
             conf['Environment'] = self.environment
 


### PR DESCRIPTION
This PR fixes cloud-custodian#5786 
AWS lambda function descriptions have a maximum length of 256 characters. Currently if a description is greater than 256, an error occurs on policy execution, not on validation.
In this PR we are trimming the description to 256 chars before the creation of the function.